### PR TITLE
Add support for YAML-CPP 0.5+.

### DIFF
--- a/bwi_mapper/CMakeLists.txt
+++ b/bwi_mapper/CMakeLists.txt
@@ -12,6 +12,10 @@ find_package(OpenCV REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(YAML_CPP REQUIRED yaml-cpp)
 
+if(NOT ${YAML_CPP_VERSION} VERSION_LESS "0.5")
+add_definitions(-DHAVE_NEW_YAMLCPP)
+endif(NOT ${YAML_CPP_VERSION} VERSION_LESS "0.5")
+
 ###################################
 ## catkin specific configuration ##
 ###################################

--- a/bwi_mapper/src/libbwi_mapper/graph.cpp
+++ b/bwi_mapper/src/libbwi_mapper/graph.cpp
@@ -44,6 +44,18 @@
 #include <bwi_mapper/map_utils.h>
 #include <bwi_mapper/point_utils.h>
 
+#ifdef HAVE_NEW_YAMLCPP
+namespace YAML {
+  // The >> operator disappeared in yaml-cpp 0.5, so this function is
+  // added to provide support for code written under the yaml-cpp 0.3 API.
+  template<typename T>
+  void operator >> (const YAML::Node& node, T& i)
+  {
+    i = node.as<T>();
+  }
+}
+#endif
+
 namespace bwi_mapper {
 
   /**
@@ -213,9 +225,13 @@ namespace bwi_mapper {
     std::vector<std::vector<size_t> > edges;
 
     std::ifstream fin(filename.c_str());
-    YAML::Parser parser(fin);
     YAML::Node doc;
+#ifdef HAVE_NEW_YAMLCPP
+    doc = YAML::Load(fin);
+#else
+    YAML::Parser parser(fin);
     parser.GetNextDocument(doc);
+#endif
     for (size_t i = 0; i < doc.size(); ++i) {
       float x, y;
       doc[i]["x"] >> x;

--- a/bwi_mapper/src/libbwi_mapper/map_loader.cpp
+++ b/bwi_mapper/src/libbwi_mapper/map_loader.cpp
@@ -44,6 +44,18 @@
 #include <bwi_mapper/map_loader.h>
 #include <bwi_mapper/map_utils.h>
 
+#ifdef HAVE_NEW_YAMLCPP
+namespace YAML {
+  // The >> operator disappeared in yaml-cpp 0.5, so this function is
+  // added to provide support for code written under the yaml-cpp 0.3 API.
+  template<typename T>
+  void operator >> (const YAML::Node& node, T& i)
+  {
+    i = node.as<T>();
+  }
+}
+#endif
+
 namespace bwi_mapper {
 
   /**
@@ -66,9 +78,13 @@ namespace bwi_mapper {
     }
 
     // Initilize parameters
-    YAML::Parser parser(fin);   
     YAML::Node doc;
+#ifdef HAVE_NEW_YAMLCPP
+    doc = YAML::Load(fin);
+#else
+    YAML::Parser parser(fin);   
     parser.GetNextDocument(doc);
+#endif
     try { 
       doc["resolution"] >> res; 
     } catch (YAML::InvalidScalar) { 

--- a/bwi_mapper/src/nodes/prepare_graph.cpp
+++ b/bwi_mapper/src/nodes/prepare_graph.cpp
@@ -5,13 +5,24 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 
+#ifdef HAVE_NEW_YAMLCPP
+namespace YAML {
+  // The >> operator disappeared in yaml-cpp 0.5, so this function is
+  // added to provide support for code written under the yaml-cpp 0.3 API.
+  template<typename T>
+  void operator >> (const YAML::Node& node, T& i)
+  {
+    i = node.as<T>();
+  }
+}
+#endif
+
 using namespace bwi_mapper;
 
 void drawElementsFile(const std::string& elements_file, cv::Mat& image,
     const Graph& graph, const nav_msgs::MapMetaData& info) {
 
   std::ifstream fin(elements_file.c_str());
-  YAML::Parser parser(fin);
 
   YAML::Node node;
   bool put_text = true;
@@ -19,10 +30,21 @@ void drawElementsFile(const std::string& elements_file, cv::Mat& image,
   std::vector<std::pair<size_t, size_t> > edges;
   std::vector<std::pair<size_t, float> > arrows;
   std::vector<int> circles, squares;
+#ifdef HAVE_NEW_YAMLCPP
+  std::vector<YAML::Node> node_vec = YAML::LoadAll(fin);
+  for(std::vector<YAML::Node>::iterator it = node_vec.begin(); it != node_vec.end(); it++) {
+    node = *it;
+#else
+  YAML::Parser parser(fin);
   while(parser.GetNextDocument(node)) {
+#endif
 
     // Get Edges
+#ifdef HAVE_NEW_YAMLCPP
+    if (node["edges"]) {
+#else
     if (node.FindValue("edges")) {
+#endif
       put_all_edges = false;
       const YAML::Node& edges_node = node["edges"];
       for(unsigned i = 0; i < edges_node.size(); ++i) {
@@ -34,7 +56,11 @@ void drawElementsFile(const std::string& elements_file, cv::Mat& image,
     }
 
     // Get Circles
+#ifdef HAVE_NEW_YAMLCPP
+    if (node["circles"]) {
+#else
     if (node.FindValue("circles")) {
+#endif
       const YAML::Node& circles_node = node["circles"];
       for(unsigned i = 0; i < circles_node.size(); ++i) {
         int circle;
@@ -44,7 +70,11 @@ void drawElementsFile(const std::string& elements_file, cv::Mat& image,
     }
 
     // Get Squares
+#ifdef HAVE_NEW_YAMLCPP
+    if (node["squares"]) {
+#else
     if (node.FindValue("squares")) {
+#endif
       const YAML::Node& squares_node = node["squares"];
       for(unsigned i = 0; i < squares_node.size(); ++i) {
         int square;
@@ -54,7 +84,11 @@ void drawElementsFile(const std::string& elements_file, cv::Mat& image,
     }
 
     // Get Directional arrows
+#ifdef HAVE_NEW_YAMLCPP
+    if (node["arrows"]) {
+#else
     if (node.FindValue("arrows")) {
+#endif
       const YAML::Node& arrows_node = node["arrows"];
       for(unsigned i = 0; i < arrows_node.size(); ++i) {
         std::pair<size_t, float> arrow;
@@ -66,7 +100,11 @@ void drawElementsFile(const std::string& elements_file, cv::Mat& image,
       }
     }
 
+#ifdef HAVE_NEW_YAMLCPP
+    if (node["put_text"]) {
+#else
     if (node.FindValue("put_text")) {
+#endif
       const YAML::Node& put_text_node = node["put_text"];
       put_text_node >> put_text;
     }

--- a/bwi_planning_common/CMakeLists.txt
+++ b/bwi_planning_common/CMakeLists.txt
@@ -7,6 +7,10 @@ find_package(PkgConfig REQUIRED)
 find_package(Boost REQUIRED COMPONENTS filesystem)
 pkg_check_modules(YAML_CPP REQUIRED yaml-cpp)
 
+if(NOT ${YAML_CPP_VERSION} VERSION_LESS "0.5")
+add_definitions(-DHAVE_NEW_YAMLCPP)
+endif(NOT ${YAML_CPP_VERSION} VERSION_LESS "0.5")
+
 add_message_files(
   FILES
   PlannerAtom.msg

--- a/bwi_planning_common/src/structures.cpp
+++ b/bwi_planning_common/src/structures.cpp
@@ -6,6 +6,18 @@
 #include <bwi_planning_common/structures.h>
 #include <tf/transform_datatypes.h> 
 
+#ifdef HAVE_NEW_YAMLCPP
+namespace YAML {
+  // The >> operator disappeared in yaml-cpp 0.5, so this function is
+  // added to provide support for code written under the yaml-cpp 0.3 API.
+  template<typename T>
+  void operator >> (const YAML::Node& node, T& i)
+  {
+    i = node.as<T>();
+  }
+}
+#endif
+
 namespace bwi_planning_common {
   
   void readLocationFile(const std::string& filename, 
@@ -15,10 +27,14 @@ namespace bwi_planning_common {
       throw std::runtime_error("Location file does not exist: " + filename);
     }
     std::ifstream fin(filename.c_str());
-    YAML::Parser parser(fin);
 
     YAML::Node doc;
+#ifdef HAVE_NEW_YAMLCPP
+    doc = YAML::Load(fin);
+#else
+    YAML::Parser parser(fin);
     parser.GetNextDocument(doc);
+#endif
 
     locations.clear();
     const YAML::Node &loc_node = doc["locations"];
@@ -42,10 +58,14 @@ namespace bwi_planning_common {
     }
 
     std::ifstream fin(filename.c_str());
-    YAML::Parser parser(fin);
 
     YAML::Node doc;
+#ifdef HAVE_NEW_YAMLCPP
+    doc = YAML::Load(fin);
+#else
+    YAML::Parser parser(fin);
     parser.GetNextDocument(doc);
+#endif
 
     doors.clear();
     for (size_t i = 0; i < doc.size(); i++) {
@@ -77,10 +97,14 @@ namespace bwi_planning_common {
     }
 
     std::ifstream fin(filename.c_str());
-    YAML::Parser parser(fin);
 
     YAML::Node doc;
+#ifdef HAVE_NEW_YAMLCPP
+    doc = YAML::Load(fin);
+#else
+    YAML::Parser parser(fin);
     parser.GetNextDocument(doc);
+#endif
 
     for (size_t i = 0; i < doc.size(); i++) {
       std::string name;


### PR DESCRIPTION
The new yaml-cpp API removes the "node >> outputvar;" operator, and it has a new way of loading documents. There's no version hint in the library's headers, so I'm getting the version number from pkg-config.

See https://github.com/ros-planning/navigation/commit/6c82fb01340ec49b68c47b9c34beb47824782a20 for more info

There was a little bit of "funky" that had to happen in `bwi_mapper/src/nodes/prepare_graph.cpp` around line 33, but other than that, all of the fixes have been implemented in other ROS packages.

Thanks!
