### PR TITLE
bwi_logging: Added ability to record experimental topics

### DIFF
--- a/bwi_logging/launch/record.launch
+++ b/bwi_logging/launch/record.launch
@@ -11,6 +11,7 @@
   <node name="record" pkg="bwi_logging" type="record"
         args="$(arg topics)">
     <param name="directory"   value="$(arg directory)"/>
+    <param name="topics"      value="$(arg topics)" />
     <param name="exp_topics"  value="$(arg exp_topics)"/>
   </node>
 

--- a/bwi_logging/launch/record.launch
+++ b/bwi_logging/launch/record.launch
@@ -12,7 +12,6 @@
         args="$(arg topics)">
     <param name="directory"   value="$(arg directory)"/>
     <param name="exp_topics"  value="$(arg exp_topics)"/>
-    <param name="topics"      value="$(arg topics)"/>
   </node>
 
 </launch>

--- a/bwi_logging/launch/record.launch
+++ b/bwi_logging/launch/record.launch
@@ -1,7 +1,8 @@
 <launch>
 
-  <arg name="directory" default="" />
-  <arg name="topics" default="odom_1hz amcl_pose /diagnostics" />
+  <arg name="directory"   default="" />
+  <arg name="topics"      default="odom_1hz amcl_pose /diagnostics" />
+  <arg name="exp_topics"  default="" />
 
   <!-- drop 99 out of every 100 messages from the odom topic -->
   <node name="drop_odom" pkg="topic_tools" type="drop"
@@ -9,7 +10,9 @@
 
   <node name="record" pkg="bwi_logging" type="record"
         args="$(arg topics)">
-    <param name="directory" value="$(arg directory)"/>
+    <param name="directory"   value="$(arg directory)"/>
+    <param name="exp_topics"  value="$(arg exp_topics)"/>
+    <param name="topics"      value="$(arg topics)"/>
   </node>
 
 </launch>

--- a/bwi_logging/src/bwi_logging/logger_node.py
+++ b/bwi_logging/src/bwi_logging/logger_node.py
@@ -90,7 +90,7 @@ def main(argv=None):
     # Record experimental topics
     experimental = False
     if exp_topics != None:
-        cmd_exp = ['rosbag', 'record', '-oexp']
+        cmd_exp = ['rosbag', 'record', '-oextra']
         cmd_exp.extend(exp_topics.split())
         rospy.loginfo('about to fork and run command: ' + str(cmd_exp))
         experimental = True
@@ -102,7 +102,6 @@ def main(argv=None):
         if pid == 0:
             return subprocess.call(cmd)
         else:
-            # delete the parameters from the server to prevent confusion
             return subprocess.call(cmd_exp)
 
 

--- a/bwi_logging/src/bwi_logging/logger_node.py
+++ b/bwi_logging/src/bwi_logging/logger_node.py
@@ -44,20 +44,13 @@ from __future__ import absolute_import, print_function
 import rospy
 import subprocess
 import sys
+import os
 
 from .directory import LoggingDirectory
 
 
 def main(argv=None):
     """ Main function. """
-    if argv is None:
-        argv = sys.argv
-    if len(argv) < 2:
-        print('error: no topics to record', file=sys.stderr)
-        print("""
-usage: rosrun bwi_logging record topic1 [ topic2 ... ]
-""", file=sys.stderr)
-        return 9
 
     # create node for reading ROS parameters
     rospy.init_node('record')
@@ -69,12 +62,48 @@ usage: rosrun bwi_logging record topic1 [ topic2 ... ]
     rospy.loginfo('logs go here: ' + logdir.pwd())
     logdir.chdir()                      # change to that directory
 
-    # this is the command we will issue:
-    cmd = ['rosbag', 'record', '-obwi']
-    cmd.extend(argv[1:])
-    rospy.loginfo('running command: ' + str(cmd))
+    # get the topics to log
+    topics = rospy.get_param('~topics', None)
+    rospy.loginfo('topics to record: ' + str(topics))
 
-    return subprocess.call(cmd)
+    # get the experimental topics to log
+    exp_topics = rospy.get_param('~exp_topics', None)
+    rospy.loginfo('exp_topics to record: ' + str(exp_topics))
+
+    # delete the parameters from the server to prevent confusion
+    if rospy.has_param("~topics"):      rospy.delete_param("~topics")
+    if rospy.has_param("~exp_topics"):  rospy.delete_param("~exp_topics")
+
+    # ensure the topics are set
+    if topics == None:
+        print('error: no topics to record', file=sys.stderr)
+        print("""
+    usage: rosrun bwi_logging _topics:=\"topic1 topic2 ...\" [_exp_topics:=\"topic3 topic4 ...\"]
+    """, file=sys.stderr)
+        return 9
+
+    # Record default topics
+    cmd = ['rosbag', 'record', '-obwi']
+    cmd.extend(topics.split())
+    rospy.loginfo('about to run command: ' + str(cmd))
+
+    # Record experimental topics
+    experimental = False
+    if exp_topics != None:
+        cmd_exp = ['rosbag', 'record', '-oexp']
+        cmd_exp.extend(exp_topics.split())
+        rospy.loginfo('about to fork and run command: ' + str(cmd_exp))
+        experimental = True
+
+    if experimental == False:
+        return subprocess.call(cmd)
+    else:
+        pid = os.fork()
+        if pid == 0:
+            return subprocess.call(cmd)
+        else:
+            # delete the parameters from the server to prevent confusion
+            return subprocess.call(cmd_exp)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is done by taking two ros parameters: one for the default parameters and one for the experimental parameters. If both are set, the node will fork so that the child can start recording the default topics and the parent can record the experimental. This solves issue #42 