### PR TITLE
sxtejeda/redundant goals

### DIFF
--- a/bwi_kr_execution/src/actions/LogicalNavigation.cpp
+++ b/bwi_kr_execution/src/actions/LogicalNavigation.cpp
@@ -68,7 +68,7 @@ void LogicalNavigation::run() {
 	//senseState takes a bit longer than 0.5f to complete, but fluents have to be updated
 	if(name == "senseState"){
 		ros::Rate wait_rate(0.5f);
-		while(!(finished_before_timeout = lnac->waitForResult(ros::Duration(0.5f))){
+		while(!(finished_before_timeout = lnac->waitForResult(ros::Duration(0.5f)))){
 			wait_rate.sleep();
 		}
 	}

--- a/bwi_kr_execution/src/actions/LogicalNavigation.cpp
+++ b/bwi_kr_execution/src/actions/LogicalNavigation.cpp
@@ -65,6 +65,14 @@ void LogicalNavigation::run() {
 
   bool finished_before_timeout = lnac->waitForResult(ros::Duration(0.5f));
 
+	//senseState takes a bit longer than 0.5f to complete, but fluents have to be updated
+	if(name == "senseState"){
+		ros::Rate wait_rate(0.5f);
+		while(!(finished_before_timeout = lnac->waitForResult(ros::Duration(0.5f))){
+			wait_rate.sleep();
+		}
+	}
+
   // If the action finished, need to do some work here.
   if (finished_before_timeout) {
     bwi_msgs::LogicalNavigationResultConstPtr result = lnac->getResult();

--- a/bwi_kr_execution/src/single_plan_executor.cpp
+++ b/bwi_kr_execution/src/single_plan_executor.cpp
@@ -85,6 +85,10 @@ void executePlan(const bwi_kr_execution::ExecutePlanGoalConstPtr& plan, Server* 
 
   transform(plan->aspGoal.begin(),plan->aspGoal.end(),back_inserter(goalRules),TranslateRule());
 
+	//Update fluents before sending new goals
+	LogicalNavigation senseState("senseState");
+	senseState.run();
+
   executor->setGoal(goalRules);
 
   ros::Rate loop(10);
@@ -107,6 +111,9 @@ void executePlan(const bwi_kr_execution::ExecutePlanGoalConstPtr& plan, Server* 
         goalRules.clear();
         const bwi_kr_execution::ExecutePlanGoalConstPtr& newGoal = as->acceptNewGoal();
         transform(newGoal->aspGoal.begin(),newGoal->aspGoal.end(),back_inserter(goalRules),TranslateRule());
+
+				//Update fluents before resending goal
+				senseState.run();
         executor->setGoal(goalRules);
       }
     }
@@ -141,7 +148,7 @@ int main(int argc, char**argv) {
     domainDirectory += '/';
 
 //  create initial state
-  LogicalNavigation setInitialState("noop");
+  LogicalNavigation setInitialState("senseState");
   setInitialState.run();
 
 


### PR DESCRIPTION
single_plan_executor now initializes with LogicalNavigation senseState, allowing for bwi_kr_execution.launch to be merged into bwi_launch. Also, senseState is now ran before sending goals to the ActionExecutor, to ensure that the bots have accurate fluents. 

These fixes are a solution for my issue #90 