### PR TITLE
Fix build errors for finding Boost

### DIFF
--- a/bwi_tools/CMakeLists.txt
+++ b/bwi_tools/CMakeLists.txt
@@ -18,7 +18,7 @@ catkin_package(
     roslib
   DEPENDS 
     OpenCV
-    BOOST
+    Boost
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME} ${PROJECT_NAME}_json
 )


### PR DESCRIPTION
When building this package, I get warnings that BOOST_INCLUDE_DIRS cannot be found. CMake package name are case-sensitive.

It may be that Boost is not even required, since the package still builds after failing to find the libraries. But either way, this removes the warning.